### PR TITLE
Fix error handler

### DIFF
--- a/express_server/app.js
+++ b/express_server/app.js
@@ -52,7 +52,7 @@ app.use(function (err, req, res, next) {
 
   // render the error page
   res.status(err.status || 500);
-  res.render('errors');
+  res.render('error');
 });
 
 // for automatic server reload


### PR DESCRIPTION
Was getting `Error: Failed to lookup view "errors" in views directory "/Users/adam/Projects/WebRTC-Simple-Peer-Examples/express_server/views"` when the server threw an error. There is a template `error.jade` but no `errors.jade`